### PR TITLE
Add user config to dockerfile

### DIFF
--- a/src/ansibleapp/dat/ex.Dockerfile
+++ b/src/ansibleapp/dat/ex.Dockerfile
@@ -6,3 +6,7 @@ LABEL "com.redhat.ansibleapp.spec"=\
 
 ADD ansible /opt/ansible
 ADD ansibleapp /opt/ansibleapp
+
+RUN useradd -u 1001 -r -g 0 -M -b /opt/ansibleapp -s /sbin/nologin -c "ansibleapp user" ansibleapp
+RUN chown -R 1001:0 /opt/{ansible,ansibleapp}
+USER 1001


### PR DESCRIPTION
This creates the ansibleapp user as the default user. Longer term (like next week probably), it would be best to have this be a flag, but I figured for now the better default behavior may be to add the user. No strong opinion either way, this is just what I'm using locally to avoid clobbering it.